### PR TITLE
Add React UI with image listing

### DIFF
--- a/api-server/main.go
+++ b/api-server/main.go
@@ -1,17 +1,30 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
+	"time"
 
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/streadway/amqp"
 )
 
 var (
 	amqpURL   string
 	queueName = "image_tasks"
+
+	minioEndpoint string
+	minioAccess   string
+	minioSecret   string
+	minioBucket   = "processed-images"
+
+	minioClient *minio.Client
 )
 
 func uploadHandler(w http.ResponseWriter, r *http.Request) {
@@ -95,6 +108,34 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("画像を受け付けました。処理を開始します。"))
 }
 
+func imagesHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := context.Background()
+	opts := minio.ListObjectsOptions{Prefix: "", Recursive: true}
+	objectCh := minioClient.ListObjects(ctx, minioBucket, opts)
+
+	type imageInfo struct {
+		Name string `json:"name"`
+		URL  string `json:"url"`
+	}
+	var images []imageInfo
+
+	for obj := range objectCh {
+		if obj.Err != nil {
+			log.Printf("ListObjects error: %v", obj.Err)
+			continue
+		}
+		presigned, err := minioClient.PresignedGetObject(ctx, minioBucket, obj.Key, time.Hour, url.Values{})
+		if err != nil {
+			log.Printf("URL生成失敗: %v", err)
+			continue
+		}
+		images = append(images, imageInfo{Name: obj.Key, URL: presigned.String()})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(images)
+}
+
 func main() {
 	// 環境変数からRabbitMQ接続先を取得（未設定ならデフォルト）
 	amqpURL = os.Getenv("AMQP_URL")
@@ -102,7 +143,30 @@ func main() {
 		amqpURL = "amqp://guest:guest@rabbitmq:5672/"
 	}
 
+	minioEndpoint = os.Getenv("MINIO_ENDPOINT")
+	if minioEndpoint == "" {
+		minioEndpoint = "minio:9000"
+	}
+	minioAccess = os.Getenv("MINIO_ACCESS_KEY")
+	if minioAccess == "" {
+		minioAccess = "minioadmin"
+	}
+	minioSecret = os.Getenv("MINIO_SECRET_KEY")
+	if minioSecret == "" {
+		minioSecret = "minioadmin"
+	}
+
+	var err error
+	minioClient, err = minio.New(minioEndpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(minioAccess, minioSecret, ""),
+		Secure: false,
+	})
+	if err != nil {
+		log.Fatalf("MinIO接続失敗: %s", err)
+	}
+
 	http.HandleFunc("/upload", uploadHandler)
+	http.HandleFunc("/images", imagesHandler)
 	// 静的ファイル（HTML, CSS, JS）は ./static 配下に配置
 	http.Handle("/", http.FileServer(http.Dir("./static")))
 	log.Println("APIサーバー起動 :8080")

--- a/api-server/static/index.html
+++ b/api-server/static/index.html
@@ -1,14 +1,76 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-    <meta charset="UTF-8">
-    <title>画像アップロード</title>
+  <meta charset="UTF-8">
+  <title>画像アップロード</title>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    img { max-width: 200px; margin: 0.5rem; }
+  </style>
 </head>
 <body>
-    <h1>画像アップロードフォーム</h1>
-    <form action="/upload" method="post" enctype="multipart/form-data">
-        <input type="file" name="image" accept="image/*" required>
-        <button type="submit">アップロード</button>
-    </form>
+  <div id="root"></div>
+  <script type="text/babel">
+    function App() {
+      const [file, setFile] = React.useState(null);
+      const [message, setMessage] = React.useState('');
+      const [images, setImages] = React.useState([]);
+
+      const fetchImages = async () => {
+        try {
+          const res = await fetch('/images');
+          const data = await res.json();
+          setImages(data);
+        } catch (err) {
+          console.error(err);
+        }
+      };
+
+      React.useEffect(() => {
+        fetchImages();
+      }, []);
+
+      const handleSubmit = async (e) => {
+        e.preventDefault();
+        if (!file) return;
+        const formData = new FormData();
+        formData.append('image', file);
+        try {
+          const res = await fetch('/upload', { method: 'POST', body: formData });
+          const text = await res.text();
+          setMessage(text);
+          setFile(null);
+          e.target.reset();
+          fetchImages();
+        } catch (err) {
+          setMessage('アップロード失敗');
+        }
+      };
+
+      return (
+        <div>
+          <h1>画像アップロード</h1>
+          <form onSubmit={handleSubmit}>
+            <input type="file" accept="image/*" onChange={e => setFile(e.target.files[0])} required />
+            <button type="submit">アップロード</button>
+          </form>
+          {message && <p>{message}</p>}
+          <h2>画像一覧</h2>
+          <div>
+            {images.map(img => (
+              <div key={img.name}>
+                <img src={img.url} alt={img.name} />
+                <p>{img.name}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      );
+    }
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
 </body>
 </html>

--- a/worker/main.go
+++ b/worker/main.go
@@ -3,12 +3,14 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"image/jpeg"
 	"log"
 	"os"
 	"time"
 
 	"github.com/disintegration/imaging"
+	"github.com/google/uuid"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/streadway/amqp"
@@ -138,13 +140,17 @@ func main() {
 				continue
 			}
 
-			// MinIOへアップロード（ここでは固定のファイル名例。実際はユニークな名前にする等の工夫が必要）
-			_, err = minioClient.PutObject(ctx, minioBucket, "resized.jpg", &bufResized, int64(bufResized.Len()), minio.PutObjectOptions{ContentType: "image/jpeg"})
+			// アップロード用のユニークなファイル名を生成
+			id := uuid.New().String()
+			resizedName := fmt.Sprintf("%s_resized.jpg", id)
+			thumbName := fmt.Sprintf("%s_thumbnail.jpg", id)
+
+			_, err = minioClient.PutObject(ctx, minioBucket, resizedName, &bufResized, int64(bufResized.Len()), minio.PutObjectOptions{ContentType: "image/jpeg"})
 			if err != nil {
 				log.Printf("リサイズ画像アップロード失敗: %s", err)
 				continue
 			}
-			_, err = minioClient.PutObject(ctx, minioBucket, "thumbnail.jpg", &bufThumb, int64(bufThumb.Len()), minio.PutObjectOptions{ContentType: "image/jpeg"})
+			_, err = minioClient.PutObject(ctx, minioBucket, thumbName, &bufThumb, int64(bufThumb.Len()), minio.PutObjectOptions{ContentType: "image/jpeg"})
 			if err != nil {
 				log.Printf("サムネイルアップロード失敗: %s", err)
 				continue


### PR DESCRIPTION
## Summary
- build a lightweight React frontend served from API server
- list processed images from MinIO via new `/images` endpoint
- generate unique names for uploaded images

## Testing
- `go vet .` in `api-server`
- `go mod tidy && go vet .` in `worker`

------
https://chatgpt.com/codex/tasks/task_e_684dd4708c2c83258d2edc8a317f0a17